### PR TITLE
Fix splitting the date and time of a question

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -17,7 +17,7 @@ def pageScraper(url):
 
     for q in questions:
         date, question = q.split('</dco>')
-        date, time = date.split('&nbsp; \\n')
+        date, time = re.split(r'&nbsp;\s?\\n', date)
         out.write('[' + date + ' - ' + time + ']' + '\n')
         soup = BeautifulSoup(question, "html.parser")
         
@@ -32,7 +32,7 @@ def pageScraper(url):
     
     for lq in lastQ:
         date, lastQuestion = lq.split('</dco>')
-        date, time = date.split('&nbsp; \\n')
+        date, time = re.split(r'&nbsp;\s?\\n', date)
         out.write('[' + date + ' - ' + time + ']' + '\n')
         question = lq.split('<\qco>')
         for sub in question:


### PR DESCRIPTION
The date and time text in a dco element can sometimes not be separated
by a space.

Example: 3.19.20&nbsp;\\n7:51 pm

The script ran into this special case today in the first page of questions and threw a ValueError exception while calling split on the date string.